### PR TITLE
Task 6: SQS & SNS, Async Microservices Communication

### DIFF
--- a/bin/cloudx-services.ts
+++ b/bin/cloudx-services.ts
@@ -5,5 +5,10 @@ import { ImportServiceStack } from "../lib/product-service/import-service-stack.
 
 const app = new cdk.App();
 
-new ProductServiceStack(app, "ProductServiceStack");
-new ImportServiceStack(app, "ImportServiceStack");
+const productsStack = new ProductServiceStack(app, "ProductServiceStack");
+const importStack = new ImportServiceStack(app, "ImportServiceStack", {
+  // @ts-ignore
+  catalogItemsQueue: productsStack.catalogItemsQueue,
+});
+
+importStack.addDependency(productsStack);

--- a/lib/product-service/catalogBatchProcess.ts
+++ b/lib/product-service/catalogBatchProcess.ts
@@ -1,0 +1,69 @@
+import { SQSEvent } from "aws-lambda";
+import {
+  DynamoDBClient,
+  TransactWriteItemsCommand,
+} from "@aws-sdk/client-dynamodb";
+import { randomUUID } from "crypto";
+
+import { HEADERS } from "./constants.js";
+
+const dynamoDBClient = new DynamoDBClient({ region: process.env.AWS_REGION });
+
+const PRODUCTS_TABLE_NAME = process.env.PRODUCTS_TABLE_NAME;
+const STOCK_TABLE_NAME = process.env.STOCK_TABLE_NAME;
+
+export const handler = async (event: SQSEvent) => {
+  console.log("Incoming event:", event);
+
+  for (const record of event.Records) {
+    try {
+      console.log("Message:", record.body);
+
+      const product = JSON.parse(record.body);
+      const productId = product.id || randomUUID();
+
+      const item = {
+        id: product.id || randomUUID(),
+        title: product.title,
+        description: product.description || "",
+        price: Number(product.price),
+        count: Number(product.count) || 0,
+      };
+
+      const transactCommand = new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Put: {
+              TableName: PRODUCTS_TABLE_NAME,
+              Item: {
+                id: { S: productId },
+                title: { S: product.title },
+                description: { S: product.description || "" },
+                price: { N: product.price.toString() },
+              },
+            },
+          },
+          {
+            Put: {
+              TableName: STOCK_TABLE_NAME,
+              Item: {
+                product_id: { S: productId },
+                count: { N: (product.count || 0).toString() },
+              },
+            },
+          },
+        ],
+      });
+
+      await dynamoDBClient.send(transactCommand);
+
+      console.log(`Created product: ${item.id}`);
+    } catch (error) {
+      console.error("Error processing message:", error);
+
+      throw error;
+    }
+  }
+
+  return { statusCode: 200, message: "Success", headers: HEADERS };
+};

--- a/lib/product-service/catalogBatchProcess.ts
+++ b/lib/product-service/catalogBatchProcess.ts
@@ -72,6 +72,12 @@ export const handler = async (event: SQSEvent) => {
           count: item.count,
         }),
         Subject: "New product created",
+        MessageAttributes: {
+          price: {
+            DataType: "Number",
+            StringValue: item.price.toString(),
+          },
+        },
       });
 
       await snsClient.send(publishCommand);

--- a/lib/product-service/product-service-stack.ts
+++ b/lib/product-service/product-service-stack.ts
@@ -13,6 +13,7 @@ import { products } from "./mock-data/products.js";
 import { stock } from "./mock-data/stock.js";
 
 const NOTIFY_EMAIL = "stepan.chopko08@gmail.com";
+const NOTIFY_EMAIL_2 = "stepanchopko49@gmail.com";
 
 export class ProductServiceStack extends cdk.Stack {
   public readonly catalogItemsQueue: sqs.Queue;
@@ -78,6 +79,17 @@ export class ProductServiceStack extends cdk.Stack {
 
     createProductTopic.addSubscription(
       new subscriptions.EmailSubscription(NOTIFY_EMAIL)
+    );
+
+    // if price grater than 1000 send to another email
+    createProductTopic.addSubscription(
+      new subscriptions.EmailSubscription(NOTIFY_EMAIL_2, {
+        filterPolicy: {
+          price: sns.SubscriptionFilter.numericFilter({
+            greaterThan: 1000,
+          }),
+        },
+      })
     );
 
     const catalogBatchProcess = new lambda.Function(

--- a/lib/product-service/product-service-stack.ts
+++ b/lib/product-service/product-service-stack.ts
@@ -11,6 +11,8 @@ import { products } from "./mock-data/products.js";
 import { stock } from "./mock-data/stock.js";
 
 export class ProductServiceStack extends cdk.Stack {
+  public readonly catalogItemsQueue: sqs.Queue;
+
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
@@ -82,17 +84,17 @@ export class ProductServiceStack extends cdk.Stack {
       }
     );
 
-    const catalogItemsQueue = new sqs.Queue(this, "catalog-items-queue", {
+    this.catalogItemsQueue = new sqs.Queue(this, "catalog-items-queue", {
       queueName: "catalogItemsQueue",
     });
 
     catalogBatchProcess.addEventSource(
-      new SqsEventSource(catalogItemsQueue, {
+      new SqsEventSource(this.catalogItemsQueue, {
         batchSize: 5,
       })
     );
 
-    catalogItemsQueue.grantConsumeMessages(catalogBatchProcess);
+    this.catalogItemsQueue.grantConsumeMessages(catalogBatchProcess);
 
     // Dynamically seed mock data into 'products' table
     products.forEach((product, index) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.901.0",
+        "@aws-sdk/client-sns": "^3.908.0",
         "@aws-sdk/client-sqs": "^3.908.0",
         "@aws-sdk/lib-dynamodb": "^3.896.0",
         "@aws-sdk/s3-request-presigner": "^3.901.0",
@@ -787,6 +788,471 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.901.0.tgz",
+      "integrity": "sha512-pxFCkuAP7Q94wMTNPAwi6hEtNrp/BdFf+HOrIEeFQsk4EoOmpKY3I6S+u6A9Wg295J80Kh74LqDWM22ux3z6Aw==",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.908.0.tgz",
+      "integrity": "sha512-GdWd0LfxZas87hQrFrM5rr2CHiKzR4GqI1C86IFXg1eWqM5/+CH9j+PAdswrh0HbqGpV5aaFyAlHEFynFDQxTw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/credential-provider-node": "3.908.0",
+        "@aws-sdk/middleware-host-header": "3.901.0",
+        "@aws-sdk/middleware-logger": "3.901.0",
+        "@aws-sdk/middleware-recursion-detection": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.908.0",
+        "@aws-sdk/region-config-resolver": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.907.0",
+        "@aws-sdk/util-user-agent-node": "3.908.0",
+        "@smithy/config-resolver": "^4.3.0",
+        "@smithy/core": "^3.15.0",
+        "@smithy/fetch-http-handler": "^5.3.1",
+        "@smithy/hash-node": "^4.2.0",
+        "@smithy/invalid-dependency": "^4.2.0",
+        "@smithy/middleware-content-length": "^4.2.0",
+        "@smithy/middleware-endpoint": "^4.3.1",
+        "@smithy/middleware-retry": "^4.4.1",
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/middleware-stack": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.1",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.0",
+        "@smithy/util-defaults-mode-node": "^4.2.1",
+        "@smithy/util-endpoints": "^3.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-retry": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sso": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.908.0.tgz",
+      "integrity": "sha512-PseFMWvtac+Q+zaY9DMISE+2+glNh0ROJ1yR4gMzeafNHSwkdYu4qcgxLWIOnIodGydBv/tQ6nzHPzExXnUUgw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/middleware-host-header": "3.901.0",
+        "@aws-sdk/middleware-logger": "3.901.0",
+        "@aws-sdk/middleware-recursion-detection": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.908.0",
+        "@aws-sdk/region-config-resolver": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.907.0",
+        "@aws-sdk/util-user-agent-node": "3.908.0",
+        "@smithy/config-resolver": "^4.3.0",
+        "@smithy/core": "^3.15.0",
+        "@smithy/fetch-http-handler": "^5.3.1",
+        "@smithy/hash-node": "^4.2.0",
+        "@smithy/invalid-dependency": "^4.2.0",
+        "@smithy/middleware-content-length": "^4.2.0",
+        "@smithy/middleware-endpoint": "^4.3.1",
+        "@smithy/middleware-retry": "^4.4.1",
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/middleware-stack": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.1",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.0",
+        "@smithy/util-defaults-mode-node": "^4.2.1",
+        "@smithy/util-endpoints": "^3.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-retry": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/core": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.908.0.tgz",
+      "integrity": "sha512-okl6FC2cQT1Oidvmnmvyp/IEvqENBagKO0ww4YV5UtBkf0VlhAymCWkZqhovtklsqgq0otag2VRPAgnrMt6nVQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/xml-builder": "3.901.0",
+        "@smithy/core": "^3.15.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/signature-v4": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.1",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.908.0.tgz",
+      "integrity": "sha512-FK2YuxoI5CxUflPOIMbVAwDbi6Xvu+2sXopXLmrHc2PfI39M3vmjEoQwYCP8WuQSRb+TbAP3xAkxHjFSBFR35w==",
+      "dependencies": {
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.908.0.tgz",
+      "integrity": "sha512-eLbz0geVW9EykujQNnYfR35Of8MreI6pau5K6XDFDUSWO9GF8wqH7CQwbXpXHBlCTHtq4QSLxzorD8U5CROhUw==",
+      "dependencies": {
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/fetch-http-handler": "^5.3.1",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.1",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-stream": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.908.0.tgz",
+      "integrity": "sha512-7Cgnv5wabgFtsgr+Uc/76EfPNGyxmbG8aICn3g3D3iJlcO4uuOZI8a77i0afoDdchZrTC6TG6UusS/NAW6zEoQ==",
+      "dependencies": {
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/credential-provider-env": "3.908.0",
+        "@aws-sdk/credential-provider-http": "3.908.0",
+        "@aws-sdk/credential-provider-process": "3.908.0",
+        "@aws-sdk/credential-provider-sso": "3.908.0",
+        "@aws-sdk/credential-provider-web-identity": "3.908.0",
+        "@aws-sdk/nested-clients": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/credential-provider-imds": "^4.2.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.908.0.tgz",
+      "integrity": "sha512-8OKbykpGw5bdfF/pLTf8YfUi1Kl8o1CTjBqWQTsLOkE3Ho3hsp1eQx8Cz4ttrpv0919kb+lox62DgmAOEmTr1w==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.908.0",
+        "@aws-sdk/credential-provider-http": "3.908.0",
+        "@aws-sdk/credential-provider-ini": "3.908.0",
+        "@aws-sdk/credential-provider-process": "3.908.0",
+        "@aws-sdk/credential-provider-sso": "3.908.0",
+        "@aws-sdk/credential-provider-web-identity": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/credential-provider-imds": "^4.2.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.908.0.tgz",
+      "integrity": "sha512-sWnbkGjDPBi6sODUzrAh5BCDpnPw0wpK8UC/hWI13Q8KGfyatAmCBfr+9OeO3+xBHa8N5AskMncr7C4qS846yQ==",
+      "dependencies": {
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.908.0.tgz",
+      "integrity": "sha512-WV/aOzuS6ZZhrkPty6TJ3ZG24iS8NXP0m3GuTVuZ5tKi9Guss31/PJ1CrKPRCYGm15CsIjf+mrUxVnNYv9ap5g==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.908.0",
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/token-providers": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.908.0.tgz",
+      "integrity": "sha512-9xWrFn6nWlF5KlV4XYW+7E6F33S3wUUEGRZ/+pgDhkIZd527ycT2nPG2dZ3fWUZMlRmzijP20QIJDqEbbGWe1Q==",
+      "dependencies": {
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/nested-clients": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.901.0.tgz",
+      "integrity": "sha512-yWX7GvRmqBtbNnUW7qbre3GvZmyYwU0WHefpZzDTYDoNgatuYq6LgUIQ+z5C04/kCRoFkAFrHag8a3BXqFzq5A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.901.0.tgz",
+      "integrity": "sha512-UoHebjE7el/tfRo8/CQTj91oNUm+5Heus5/a4ECdmWaSCHCS/hXTsU3PTTHAY67oAQR8wBLFPfp3mMvXjB+L2A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.901.0.tgz",
+      "integrity": "sha512-Wd2t8qa/4OL0v/oDpCHHYkgsXJr8/ttCxrvCKAt0H1zZe2LlRhY9gpDVKqdertfHrHDj786fOvEQA28G1L75Dg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@aws/lambda-invoke-store": "^0.0.1",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.908.0.tgz",
+      "integrity": "sha512-R0ePEOku72EvyJWy/D0Z5f/Ifpfxa0U9gySO3stpNhOox87XhsILpcIsCHPy0OHz1a7cMoZsF6rMKSzDeCnogQ==",
+      "dependencies": {
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@smithy/core": "^3.15.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.908.0.tgz",
+      "integrity": "sha512-ZxDYrfxOKXNFHLyvJtT96TJ0p4brZOhwRE4csRXrezEVUN+pNgxuem95YvMALPVhlVqON2CTzr8BX+CcBKvX9Q==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/middleware-host-header": "3.901.0",
+        "@aws-sdk/middleware-logger": "3.901.0",
+        "@aws-sdk/middleware-recursion-detection": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.908.0",
+        "@aws-sdk/region-config-resolver": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.907.0",
+        "@aws-sdk/util-user-agent-node": "3.908.0",
+        "@smithy/config-resolver": "^4.3.0",
+        "@smithy/core": "^3.15.0",
+        "@smithy/fetch-http-handler": "^5.3.1",
+        "@smithy/hash-node": "^4.2.0",
+        "@smithy/invalid-dependency": "^4.2.0",
+        "@smithy/middleware-content-length": "^4.2.0",
+        "@smithy/middleware-endpoint": "^4.3.1",
+        "@smithy/middleware-retry": "^4.4.1",
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/middleware-stack": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.1",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.0",
+        "@smithy/util-defaults-mode-node": "^4.2.1",
+        "@smithy/util-endpoints": "^3.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-retry": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.901.0.tgz",
+      "integrity": "sha512-7F0N888qVLHo4CSQOsnkZ4QAp8uHLKJ4v3u09Ly5k4AEStrSlFpckTPyUx6elwGL+fxGjNE2aakK8vEgzzCV0A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/token-providers": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.908.0.tgz",
+      "integrity": "sha512-4SosHWRQ8hj1X2yDenCYHParcCjHcd7S+Mdb/lelwF0JBFCNC+dNCI9ws3cP/dFdZO/AIhJQGUBzEQtieloixw==",
+      "dependencies": {
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/nested-clients": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/types": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.901.0.tgz",
+      "integrity": "sha512-FfEM25hLEs4LoXsLXQ/q6X6L4JmKkKkbVFpKD4mwfVHtRVQG6QxJiCPcrkcPISquiy6esbwK2eh64TWbiD60cg==",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.901.0.tgz",
+      "integrity": "sha512-5nZP3hGA8FHEtKvEQf4Aww5QZOkjLW1Z+NixSd+0XKfHvA39Ah5sZboScjLx0C9kti/K3OGW1RCx5K9Zc3bZqg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.907.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.907.0.tgz",
+      "integrity": "sha512-Hus/2YCQmtCEfr4Ls88d07Q99Ex59uvtktiPTV963Q7w7LHuIT/JBjrbwNxtSm2KlJR9PHNdqxwN+fSuNsMGMQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/types": "^4.6.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.908.0.tgz",
+      "integrity": "sha512-l6AEaKUAYarcEy8T8NZ+dNZ00VGLs3fW2Cqu1AuPENaSad0/ahEU+VU7MpXS8FhMRGPgplxKVgCTLyTY0Lbssw==",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/xml-builder": {
       "version": "3.901.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.901.0.tgz",
       "integrity": "sha512-pxFCkuAP7Q94wMTNPAwi6hEtNrp/BdFf+HOrIEeFQsk4EoOmpKY3I6S+u6A9Wg295J80Kh74LqDWM22ux3z6Aw==",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.901.0",
+        "@aws-sdk/client-sqs": "^3.908.0",
         "@aws-sdk/lib-dynamodb": "^3.896.0",
         "@aws-sdk/s3-request-presigner": "^3.901.0",
         "aws-cdk": "2.1029.1",
@@ -798,6 +799,473 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.908.0.tgz",
+      "integrity": "sha512-cUnu1EQTW9heKGvnl6mDna2RwTDq3FzoKRedmju+0eTxPzQe79vG3Pab8+uXyEIhluZxpx/q6VJEHFxbtRX5rQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/credential-provider-node": "3.908.0",
+        "@aws-sdk/middleware-host-header": "3.901.0",
+        "@aws-sdk/middleware-logger": "3.901.0",
+        "@aws-sdk/middleware-recursion-detection": "3.901.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.908.0",
+        "@aws-sdk/middleware-user-agent": "3.908.0",
+        "@aws-sdk/region-config-resolver": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.907.0",
+        "@aws-sdk/util-user-agent-node": "3.908.0",
+        "@smithy/config-resolver": "^4.3.0",
+        "@smithy/core": "^3.15.0",
+        "@smithy/fetch-http-handler": "^5.3.1",
+        "@smithy/hash-node": "^4.2.0",
+        "@smithy/invalid-dependency": "^4.2.0",
+        "@smithy/md5-js": "^4.2.0",
+        "@smithy/middleware-content-length": "^4.2.0",
+        "@smithy/middleware-endpoint": "^4.3.1",
+        "@smithy/middleware-retry": "^4.4.1",
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/middleware-stack": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.1",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.0",
+        "@smithy/util-defaults-mode-node": "^4.2.1",
+        "@smithy/util-endpoints": "^3.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-retry": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sso": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.908.0.tgz",
+      "integrity": "sha512-PseFMWvtac+Q+zaY9DMISE+2+glNh0ROJ1yR4gMzeafNHSwkdYu4qcgxLWIOnIodGydBv/tQ6nzHPzExXnUUgw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/middleware-host-header": "3.901.0",
+        "@aws-sdk/middleware-logger": "3.901.0",
+        "@aws-sdk/middleware-recursion-detection": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.908.0",
+        "@aws-sdk/region-config-resolver": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.907.0",
+        "@aws-sdk/util-user-agent-node": "3.908.0",
+        "@smithy/config-resolver": "^4.3.0",
+        "@smithy/core": "^3.15.0",
+        "@smithy/fetch-http-handler": "^5.3.1",
+        "@smithy/hash-node": "^4.2.0",
+        "@smithy/invalid-dependency": "^4.2.0",
+        "@smithy/middleware-content-length": "^4.2.0",
+        "@smithy/middleware-endpoint": "^4.3.1",
+        "@smithy/middleware-retry": "^4.4.1",
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/middleware-stack": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.1",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.0",
+        "@smithy/util-defaults-mode-node": "^4.2.1",
+        "@smithy/util-endpoints": "^3.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-retry": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/core": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.908.0.tgz",
+      "integrity": "sha512-okl6FC2cQT1Oidvmnmvyp/IEvqENBagKO0ww4YV5UtBkf0VlhAymCWkZqhovtklsqgq0otag2VRPAgnrMt6nVQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/xml-builder": "3.901.0",
+        "@smithy/core": "^3.15.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/signature-v4": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.1",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.908.0.tgz",
+      "integrity": "sha512-FK2YuxoI5CxUflPOIMbVAwDbi6Xvu+2sXopXLmrHc2PfI39M3vmjEoQwYCP8WuQSRb+TbAP3xAkxHjFSBFR35w==",
+      "dependencies": {
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.908.0.tgz",
+      "integrity": "sha512-eLbz0geVW9EykujQNnYfR35Of8MreI6pau5K6XDFDUSWO9GF8wqH7CQwbXpXHBlCTHtq4QSLxzorD8U5CROhUw==",
+      "dependencies": {
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/fetch-http-handler": "^5.3.1",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.1",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-stream": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.908.0.tgz",
+      "integrity": "sha512-7Cgnv5wabgFtsgr+Uc/76EfPNGyxmbG8aICn3g3D3iJlcO4uuOZI8a77i0afoDdchZrTC6TG6UusS/NAW6zEoQ==",
+      "dependencies": {
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/credential-provider-env": "3.908.0",
+        "@aws-sdk/credential-provider-http": "3.908.0",
+        "@aws-sdk/credential-provider-process": "3.908.0",
+        "@aws-sdk/credential-provider-sso": "3.908.0",
+        "@aws-sdk/credential-provider-web-identity": "3.908.0",
+        "@aws-sdk/nested-clients": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/credential-provider-imds": "^4.2.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.908.0.tgz",
+      "integrity": "sha512-8OKbykpGw5bdfF/pLTf8YfUi1Kl8o1CTjBqWQTsLOkE3Ho3hsp1eQx8Cz4ttrpv0919kb+lox62DgmAOEmTr1w==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.908.0",
+        "@aws-sdk/credential-provider-http": "3.908.0",
+        "@aws-sdk/credential-provider-ini": "3.908.0",
+        "@aws-sdk/credential-provider-process": "3.908.0",
+        "@aws-sdk/credential-provider-sso": "3.908.0",
+        "@aws-sdk/credential-provider-web-identity": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/credential-provider-imds": "^4.2.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.908.0.tgz",
+      "integrity": "sha512-sWnbkGjDPBi6sODUzrAh5BCDpnPw0wpK8UC/hWI13Q8KGfyatAmCBfr+9OeO3+xBHa8N5AskMncr7C4qS846yQ==",
+      "dependencies": {
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.908.0.tgz",
+      "integrity": "sha512-WV/aOzuS6ZZhrkPty6TJ3ZG24iS8NXP0m3GuTVuZ5tKi9Guss31/PJ1CrKPRCYGm15CsIjf+mrUxVnNYv9ap5g==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.908.0",
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/token-providers": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.908.0.tgz",
+      "integrity": "sha512-9xWrFn6nWlF5KlV4XYW+7E6F33S3wUUEGRZ/+pgDhkIZd527ycT2nPG2dZ3fWUZMlRmzijP20QIJDqEbbGWe1Q==",
+      "dependencies": {
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/nested-clients": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.901.0.tgz",
+      "integrity": "sha512-yWX7GvRmqBtbNnUW7qbre3GvZmyYwU0WHefpZzDTYDoNgatuYq6LgUIQ+z5C04/kCRoFkAFrHag8a3BXqFzq5A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.901.0.tgz",
+      "integrity": "sha512-UoHebjE7el/tfRo8/CQTj91oNUm+5Heus5/a4ECdmWaSCHCS/hXTsU3PTTHAY67oAQR8wBLFPfp3mMvXjB+L2A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.901.0.tgz",
+      "integrity": "sha512-Wd2t8qa/4OL0v/oDpCHHYkgsXJr8/ttCxrvCKAt0H1zZe2LlRhY9gpDVKqdertfHrHDj786fOvEQA28G1L75Dg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@aws/lambda-invoke-store": "^0.0.1",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.908.0.tgz",
+      "integrity": "sha512-R0ePEOku72EvyJWy/D0Z5f/Ifpfxa0U9gySO3stpNhOox87XhsILpcIsCHPy0OHz1a7cMoZsF6rMKSzDeCnogQ==",
+      "dependencies": {
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@smithy/core": "^3.15.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.908.0.tgz",
+      "integrity": "sha512-ZxDYrfxOKXNFHLyvJtT96TJ0p4brZOhwRE4csRXrezEVUN+pNgxuem95YvMALPVhlVqON2CTzr8BX+CcBKvX9Q==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/middleware-host-header": "3.901.0",
+        "@aws-sdk/middleware-logger": "3.901.0",
+        "@aws-sdk/middleware-recursion-detection": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.908.0",
+        "@aws-sdk/region-config-resolver": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.907.0",
+        "@aws-sdk/util-user-agent-node": "3.908.0",
+        "@smithy/config-resolver": "^4.3.0",
+        "@smithy/core": "^3.15.0",
+        "@smithy/fetch-http-handler": "^5.3.1",
+        "@smithy/hash-node": "^4.2.0",
+        "@smithy/invalid-dependency": "^4.2.0",
+        "@smithy/middleware-content-length": "^4.2.0",
+        "@smithy/middleware-endpoint": "^4.3.1",
+        "@smithy/middleware-retry": "^4.4.1",
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/middleware-stack": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.1",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.0",
+        "@smithy/util-defaults-mode-node": "^4.2.1",
+        "@smithy/util-endpoints": "^3.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-retry": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.901.0.tgz",
+      "integrity": "sha512-7F0N888qVLHo4CSQOsnkZ4QAp8uHLKJ4v3u09Ly5k4AEStrSlFpckTPyUx6elwGL+fxGjNE2aakK8vEgzzCV0A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/token-providers": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.908.0.tgz",
+      "integrity": "sha512-4SosHWRQ8hj1X2yDenCYHParcCjHcd7S+Mdb/lelwF0JBFCNC+dNCI9ws3cP/dFdZO/AIhJQGUBzEQtieloixw==",
+      "dependencies": {
+        "@aws-sdk/core": "3.908.0",
+        "@aws-sdk/nested-clients": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/types": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.901.0.tgz",
+      "integrity": "sha512-FfEM25hLEs4LoXsLXQ/q6X6L4JmKkKkbVFpKD4mwfVHtRVQG6QxJiCPcrkcPISquiy6esbwK2eh64TWbiD60cg==",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.901.0.tgz",
+      "integrity": "sha512-5nZP3hGA8FHEtKvEQf4Aww5QZOkjLW1Z+NixSd+0XKfHvA39Ah5sZboScjLx0C9kti/K3OGW1RCx5K9Zc3bZqg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.907.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.907.0.tgz",
+      "integrity": "sha512-Hus/2YCQmtCEfr4Ls88d07Q99Ex59uvtktiPTV963Q7w7LHuIT/JBjrbwNxtSm2KlJR9PHNdqxwN+fSuNsMGMQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/types": "^4.6.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.908.0.tgz",
+      "integrity": "sha512-l6AEaKUAYarcEy8T8NZ+dNZ00VGLs3fW2Cqu1AuPENaSad0/ahEU+VU7MpXS8FhMRGPgplxKVgCTLyTY0Lbssw==",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.908.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.901.0.tgz",
+      "integrity": "sha512-pxFCkuAP7Q94wMTNPAwi6hEtNrp/BdFf+HOrIEeFQsk4EoOmpKY3I6S+u6A9Wg295J80Kh74LqDWM22ux3z6Aw==",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.896.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.896.0.tgz",
@@ -1319,6 +1787,34 @@
       "dependencies": {
         "@smithy/types": "^4.6.0",
         "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.908.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.908.0.tgz",
+      "integrity": "sha512-coPoGdyDzFg/gNMIEeVoysQqMRpt2jB68KJZRdsitHZSW95SQSo1hW7atpFec+z9xorsy/X7Vop0iJZdQlUIYA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/smithy-client": "^4.7.1",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/@aws-sdk/types": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.901.0.tgz",
+      "integrity": "sha512-FfEM25hLEs4LoXsLXQ/q6X6L4JmKkKkbVFpKD4mwfVHtRVQG6QxJiCPcrkcPISquiy6esbwK2eh64TWbiD60cg==",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3396,17 +3892,17 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.14.0.tgz",
-      "integrity": "sha512-XJ4z5FxvY/t0Dibms/+gLJrI5niRoY0BCmE02fwmPcRYFPI4KI876xaE79YGWIKnEslMbuQPsIEsoU/DXa0DoA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.15.0.tgz",
+      "integrity": "sha512-VJWncXgt+ExNn0U2+Y7UywuATtRYaodGQKFo9mDyh70q+fJGedfrqi2XuKU1BhiLeXgg6RZrW7VEKfeqFhHAJA==",
       "dependencies": {
         "@smithy/middleware-serde": "^4.2.0",
         "@smithy/protocol-http": "^5.3.0",
         "@smithy/types": "^4.6.0",
-        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-middleware": "^4.2.0",
-        "@smithy/util-stream": "^4.4.0",
+        "@smithy/util-stream": "^4.5.0",
         "@smithy/util-utf8": "^4.2.0",
         "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
@@ -3496,14 +3992,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.0.tgz",
-      "integrity": "sha512-BG3KSmsx9A//KyIfw+sqNmWFr1YBUr+TwpxFT7yPqAk0yyDh7oSNgzfNH7pS6OC099EGx2ltOULvumCFe8bcgw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.1.tgz",
+      "integrity": "sha512-3AvYYbB+Dv5EPLqnJIAgYw/9+WzeBiUYS8B+rU0pHq5NMQMvrZmevUROS4V2GAt0jEOn9viBzPLrZE+riTNd5Q==",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.0",
         "@smithy/querystring-builder": "^4.2.0",
         "@smithy/types": "^4.6.0",
-        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-base64": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3601,11 +4097,11 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.0.tgz",
-      "integrity": "sha512-jFVjuQeV8TkxaRlcCNg0GFVgg98tscsmIrIwRFeC74TIUyLE3jmY9xgc1WXrPQYRjQNK3aRoaIk6fhFRGOIoGw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.1.tgz",
+      "integrity": "sha512-JtM4SjEgImLEJVXdsbvWHYiJ9dtuKE8bqLlvkvGi96LbejDL6qnVpVxEFUximFodoQbg0Gnkyff9EKUhFhVJFw==",
       "dependencies": {
-        "@smithy/core": "^3.14.0",
+        "@smithy/core": "^3.15.0",
         "@smithy/middleware-serde": "^4.2.0",
         "@smithy/node-config-provider": "^4.3.0",
         "@smithy/shared-ini-file-loader": "^4.3.0",
@@ -3619,14 +4115,14 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.0.tgz",
-      "integrity": "sha512-yaVBR0vQnOnzex45zZ8ZrPzUnX73eUC8kVFaAAbn04+6V7lPtxn56vZEBBAhgS/eqD6Zm86o6sJs6FuQVoX5qg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.1.tgz",
+      "integrity": "sha512-wXxS4ex8cJJteL0PPQmWYkNi9QKDWZIpsndr0wZI2EL+pSSvA/qqxXU60gBOJoIc2YgtZSWY/PE86qhKCCKP1w==",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.0",
         "@smithy/protocol-http": "^5.3.0",
         "@smithy/service-error-classification": "^4.2.0",
-        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/smithy-client": "^4.7.1",
         "@smithy/types": "^4.6.0",
         "@smithy/util-middleware": "^4.2.0",
         "@smithy/util-retry": "^4.2.0",
@@ -3782,16 +4278,16 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.7.0.tgz",
-      "integrity": "sha512-3BDx/aCCPf+kkinYf5QQhdQ9UAGihgOVqI3QO5xQfSaIWvUE4KYLtiGRWsNe1SR7ijXC0QEPqofVp5Sb0zC8xQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.7.1.tgz",
+      "integrity": "sha512-WXVbiyNf/WOS/RHUoFMkJ6leEVpln5ojCjNBnzoZeMsnCg3A0BRhLK3WYc4V7PmYcYPZh9IYzzAg9XcNSzYxYQ==",
       "dependencies": {
-        "@smithy/core": "^3.14.0",
-        "@smithy/middleware-endpoint": "^4.3.0",
+        "@smithy/core": "^3.15.0",
+        "@smithy/middleware-endpoint": "^4.3.1",
         "@smithy/middleware-stack": "^4.2.0",
         "@smithy/protocol-http": "^5.3.0",
         "@smithy/types": "^4.6.0",
-        "@smithy/util-stream": "^4.4.0",
+        "@smithy/util-stream": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3823,9 +4319,9 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.2.0.tgz",
-      "integrity": "sha512-+erInz8WDv5KPe7xCsJCp+1WCjSbah9gWcmUXc9NqmhyPx59tf7jqFz+za1tRG1Y5KM1Cy1rWCcGypylFp4mvA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.0",
         "@smithy/util-utf8": "^4.2.0",
@@ -3847,9 +4343,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.0.tgz",
-      "integrity": "sha512-U8q1WsSZFjXijlD7a4wsDQOvOwV+72iHSfq1q7VD+V75xP/pdtm0WIGuaFJ3gcADDOKj2MIBn4+zisi140HEnQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3881,14 +4377,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.2.0.tgz",
-      "integrity": "sha512-qzHp7ZDk1Ba4LDwQVCNp90xPGqSu7kmL7y5toBpccuhi3AH7dcVBIT/pUxYcInK4jOy6FikrcTGq5wxcka8UaQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.0.tgz",
+      "integrity": "sha512-H4MAj8j8Yp19Mr7vVtGgi7noJjvjJbsKQJkvNnLlrIFduRFT5jq5Eri1k838YW7rN2g5FTnXpz5ktKVr1KVgPQ==",
       "dependencies": {
         "@smithy/property-provider": "^4.2.0",
-        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/smithy-client": "^4.7.1",
         "@smithy/types": "^4.6.0",
-        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3896,15 +4391,15 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.0.tgz",
-      "integrity": "sha512-FxUHS3WXgx3bTWR6yQHNHHkQHZm/XKIi/CchTnKvBulN6obWpcbzJ6lDToXn+Wp0QlVKd7uYAz2/CTw1j7m+Kg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.1.tgz",
+      "integrity": "sha512-PuDcgx7/qKEMzV1QFHJ7E4/MMeEjaA7+zS5UNcHCLPvvn59AeZQ0DSDGMpqC2xecfa/1cNGm4l8Ec/VxCuY7Ug==",
       "dependencies": {
         "@smithy/config-resolver": "^4.3.0",
         "@smithy/credential-provider-imds": "^4.2.0",
         "@smithy/node-config-provider": "^4.3.0",
         "@smithy/property-provider": "^4.2.0",
-        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/smithy-client": "^4.7.1",
         "@smithy/types": "^4.6.0",
         "tslib": "^2.6.2"
       },
@@ -3962,14 +4457,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.4.0.tgz",
-      "integrity": "sha512-vtO7ktbixEcrVzMRmpQDnw/Ehr9UWjBvSJ9fyAbadKkC4w5Cm/4lMO8cHz8Ysb8uflvQUNRcuux/oNHKPXkffg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.0.tgz",
+      "integrity": "sha512-0TD5M5HCGu5diEvZ/O/WquSjhJPasqv7trjoqHyWjNh/FBeBl7a0ztl9uFMOsauYtRfd8jvpzIAQhDHbx+nvZw==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.0",
+        "@smithy/fetch-http-handler": "^5.3.1",
         "@smithy/node-http-handler": "^4.3.0",
         "@smithy/types": "^4.6.0",
-        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-base64": "^4.3.0",
         "@smithy/util-buffer-from": "^4.2.0",
         "@smithy/util-hex-encoding": "^4.2.0",
         "@smithy/util-utf8": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",
+    "@aws-sdk/client-sns": "^3.908.0",
     "@aws-sdk/client-sqs": "^3.908.0",
     "@aws-sdk/lib-dynamodb": "^3.896.0",
     "@aws-sdk/s3-request-presigner": "^3.901.0",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
     "typescript": "~5.6.3"
   },
   "dependencies": {
-    "aws-cdk": "2.1029.1",
     "@aws-sdk/client-s3": "^3.901.0",
+    "@aws-sdk/client-sqs": "^3.908.0",
     "@aws-sdk/lib-dynamodb": "^3.896.0",
     "@aws-sdk/s3-request-presigner": "^3.901.0",
+    "aws-cdk": "2.1029.1",
     "aws-cdk-lib": "2.214.0",
     "constructs": "^10.0.0",
     "csv-parser": "^3.2.0"

--- a/test/create-batch-process.test.ts
+++ b/test/create-batch-process.test.ts
@@ -1,0 +1,197 @@
+import { handler as catalogBatchProcessHandler } from "../lib/product-service/catalogBatchProcess";
+import {
+  DynamoDBClient,
+  TransactWriteItemsCommand,
+} from "@aws-sdk/client-dynamodb";
+import { SNSClient, PublishCommand } from "@aws-sdk/client-sns";
+import { mockClient } from "aws-sdk-client-mock";
+import { SQSEvent, SQSRecord } from "aws-lambda";
+
+const dynamoMock = mockClient(DynamoDBClient);
+const snsMock = mockClient(SNSClient);
+
+describe("catalogBatchProcessHandler", () => {
+  beforeEach(() => {
+    dynamoMock.reset();
+    snsMock.reset();
+  });
+
+  it("should process SQS messages, write to DynamoDB, and publish to SNS", async () => {
+    dynamoMock.on(TransactWriteItemsCommand).resolves({});
+    snsMock.on(PublishCommand).resolves({ MessageId: "mockMessageId" });
+
+    const event: SQSEvent = {
+      Records: [
+        {
+          body: JSON.stringify({
+            id: "product-id-1",
+            title: "Product",
+            description: "Product description",
+            price: 100,
+            count: 5,
+          }),
+        },
+      ] as SQSRecord[],
+    };
+
+    const response = await catalogBatchProcessHandler(event);
+
+    expect(dynamoMock.calls()).toHaveLength(1);
+    expect(dynamoMock.call(0).args[0].input).toEqual({
+      TransactItems: [
+        {
+          Put: {
+            TableName: process.env.PRODUCTS_TABLE_NAME,
+            Item: {
+              id: { S: "product-id-1" },
+              title: { S: "Product" },
+              description: { S: "Product description" },
+              price: { N: "100" },
+            },
+          },
+        },
+        {
+          Put: {
+            TableName: process.env.STOCK_TABLE_NAME,
+            Item: {
+              product_id: { S: "product-id-1" },
+              count: { N: "5" },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(snsMock.calls()).toHaveLength(1);
+    expect(snsMock.call(0).args[0].input).toEqual({
+      TopicArn: process.env.CREATE_PRODUCT_TOPIC_ARN,
+      Message: JSON.stringify({
+        id: "product-id-1",
+        title: "Product",
+        description: "Product description",
+        price: 100,
+        count: 5,
+      }),
+      Subject: "New product created",
+      MessageAttributes: {
+        price: {
+          DataType: "Number",
+          StringValue: "100",
+        },
+      },
+    });
+
+    expect(response).toEqual({
+      statusCode: 200,
+      message: "Success",
+      headers: expect.any(Object),
+    });
+  });
+
+  it("should handle errors from DynamoDB", async () => {
+    dynamoMock
+      .on(TransactWriteItemsCommand)
+      .rejects(new Error("DynamoDB error"));
+
+    const event: SQSEvent = {
+      Records: [
+        {
+          body: JSON.stringify({
+            id: "product-id-1",
+            title: "Product",
+            description: "Product description",
+            price: 100,
+            count: 5,
+          }),
+        },
+      ] as SQSRecord[],
+    };
+
+    await expect(catalogBatchProcessHandler(event)).rejects.toThrow(
+      "DynamoDB error"
+    );
+
+    expect(dynamoMock.calls()).toHaveLength(1);
+    expect(snsMock.calls()).toHaveLength(0);
+  });
+
+  it("should handle errors from SNS", async () => {
+    dynamoMock.on(TransactWriteItemsCommand).resolves({});
+    snsMock.on(PublishCommand).rejects(new Error("SNS error"));
+
+    const event: SQSEvent = {
+      Records: [
+        {
+          body: JSON.stringify({
+            id: "product-id-1",
+            title: "Product",
+            description: "Product description",
+            price: 100,
+            count: 5,
+          }),
+        },
+      ] as SQSRecord[],
+    };
+
+    await expect(catalogBatchProcessHandler(event)).rejects.toThrow(
+      "SNS error"
+    );
+
+    expect(dynamoMock.calls()).toHaveLength(1);
+    expect(snsMock.calls()).toHaveLength(1);
+  });
+
+  it("should handle invalid SQS message format", async () => {
+    const event: SQSEvent = {
+      Records: [
+        {
+          body: "invalid-json",
+        },
+      ] as SQSRecord[],
+    };
+
+    await expect(catalogBatchProcessHandler(event)).rejects.toThrow();
+
+    expect(dynamoMock.calls()).toHaveLength(0);
+    expect(snsMock.calls()).toHaveLength(0);
+  });
+
+  it("should process multiple SQS messages", async () => {
+    dynamoMock.on(TransactWriteItemsCommand).resolves({});
+    snsMock.on(PublishCommand).resolves({ MessageId: "mockMessageId" });
+
+    const event: SQSEvent = {
+      Records: [
+        {
+          body: JSON.stringify({
+            id: "product-id-1",
+            title: "Product 1",
+            description: "Description 1",
+            price: 50,
+            count: 10,
+          }),
+        },
+        {
+          body: JSON.stringify({
+            id: "product-id-2",
+            title: "Product 2",
+            description: "Description 2",
+            price: 150,
+            count: 20,
+          }),
+        },
+      ] as SQSRecord[],
+    };
+
+    const response = await catalogBatchProcessHandler(event);
+
+    expect(dynamoMock.calls()).toHaveLength(2);
+    expect(snsMock.calls()).toHaveLength(2);
+
+    expect(response).toEqual({
+      statusCode: 200,
+      message: "Success",
+      headers: expect.any(Object),
+    });
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     "lib/product-service/createProduct.ts",
     "lib/product-service/importProductsFile.ts",
     "lib/product-service/importFileParser.ts",
+    "lib/product-service/catalogBatchProcess.ts",
   ],
   target: "node20",
   splitting: false,


### PR DESCRIPTION
Product Service Stack updated with:

- `catalogBatchProcess` Lambda function triggered by SQS events to process batches of 5 messages and create products in the DynamoDB products table.
- `catalogItemsQueue` SQS queue configuration to trigger the `catalogBatchProcess` Lambda.
- `createProductTopic` SNS topic with email subscriptions, including a Filter Policy for distributing messages based on product attributes.
- Updated `importFileParser` Lambda in the Import Service to send CSV records to SQS instead of logging to CloudWatch.
- Unit test coverage for the `catalogBatchProcess` Lambda function.

Links:  
Import Service API: https://48bqrteo6h.execute-api.us-east-1.amazonaws.com/prod/import?name=test.csv